### PR TITLE
[AMD] Add rocshmem device APIs for get/put/sync operations

### DIFF
--- a/third_party/amd/language/hip/librocshmem_device.py
+++ b/third_party/amd/language/hip/librocshmem_device.py
@@ -473,28 +473,28 @@ def putmem_signal_nbi_wave(dest,
 
 
 
-@core.extern
-def wait_until(sig_addr, cmp_, cmp_val, _semantic=None):
-    tl.static_assert(sig_addr.dtype == pi_u64_t or sig_addr.dtype == pi_i64_t,
-                     "sig_addr should be a pointer of uint64_t/int64_t",
-                     _semantic=_semantic)
-    return extern_call(
-        "librocshmem_device",
-        "",
-        [
-            tl.cast(sig_addr, pi_u64_t, _semantic=_semantic),
-            tl.cast(cmp_, tl.int32, _semantic=_semantic),
-            tl.cast(cmp_val, tl.uint64, _semantic=_semantic),
-        ],  # no cast
-        {
-            (pi_u64_t, tl.int32, tl.uint64): (
-                "rocshmem_wait_until_wrapper",
-                (),
-            ),
-        },
-        is_pure=False,
-        _semantic=_semantic,
-    )
+# @core.extern
+# def wait_until(sig_addr, cmp_, cmp_val, _semantic=None):
+#     tl.static_assert(sig_addr.dtype == pi_u64_t or sig_addr.dtype == pi_i64_t,
+#                      "sig_addr should be a pointer of uint64_t/int64_t",
+#                      _semantic=_semantic)
+#     return extern_call(
+#         "librocshmem_device",
+#         "",
+#         [
+#             tl.cast(sig_addr, pi_u64_t, _semantic=_semantic),
+#             tl.cast(cmp_, tl.int32, _semantic=_semantic),
+#             tl.cast(cmp_val, tl.uint64, _semantic=_semantic),
+#         ],  # no cast
+#         {
+#             (pi_u64_t, tl.int32, tl.uint64): (
+#                 "rocshmem_wait_until_wrapper",
+#                 (),
+#             ),
+#         },
+#         is_pure=False,
+#         _semantic=_semantic,
+#     )
 
 
 @core.extern
@@ -535,7 +535,7 @@ def fence(_semantic=None):
         "",
         [],
         {
-            (): ("rocshmem_fence", ()),
+            (): ("rocshmem_fence_wrapper", ()),
         },
         is_pure=False,
         _semantic=_semantic,

--- a/third_party/amd/language/hip/librocshmem_device.py
+++ b/third_party/amd/language/hip/librocshmem_device.py
@@ -26,6 +26,20 @@ from triton.language import core
 import triton.language as tl
 from triton_dist.language.core import extern_call
 
+pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
+pi_i64_t = tl.core.pointer_type(tl.core.dtype("int64"))
+
+# ROCSHMEM_CMPS (enum)
+ROCSHMEM_CMP_EQ = 0
+ROCSHMEM_CMP_NE = 1
+ROCSHMEM_CMP_GT = 2
+ROCSHMEM_CMP_GE = 3
+ROCSHMEM_CMP_LT = 4
+ROCSHMEM_CMP_LE = 5
+
+# ROCSHMEM_SIGNAL_OPS (enum)
+ROCSHMEM_SIGNAL_SET = 0
+ROCSHMEM_SIGNAL_ADD = 1
 
 @core.extern
 def set_rocshmem_ctx(ctx, _semantic=None):
@@ -99,5 +113,430 @@ def remote_ptr(local_ptr, pe, _semantic=None):
             _semantic=_semantic,
         ),
         local_ptr.dtype,
+        _semantic=_semantic,
+    )
+
+@core.extern
+def _getmem_impl(dest,
+                 source,
+                 nbytes,
+                 pe,
+                 SCOPE_SUFFIX: core.constexpr,
+                 NBI: core.constexpr = core.constexpr(""),
+                 _semantic=None):
+    return extern_call(
+        "librocshmem_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32):
+            (
+                f"rocshmem_getmem{NBI.value}{SCOPE_SUFFIX.value}_wrapper",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def getmem(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr(""),
+                        core.constexpr(""),
+                        _semantic=_semantic)
+
+
+@core.extern
+def getmem_wave(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr("_wave"),
+                        core.constexpr(""),
+                        _semantic=_semantic)
+
+
+
+@core.extern
+def getmem_wg(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr("_wg"),
+                        core.constexpr(""),
+                        _semantic=_semantic)
+
+
+@core.extern
+def getmem_nbi(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr(""),
+                        core.constexpr("_nbi"),
+                        _semantic=_semantic)
+
+
+@core.extern
+def getmem_nbi_wave(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr("_wave"),
+                        core.constexpr("_nbi"),
+                        _semantic=_semantic)
+
+
+@core.extern
+def getmem_nbi_wg(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr("_wg"),
+                        core.constexpr("_nbi"),
+                        _semantic=_semantic)
+
+
+@core.extern
+def _putmem_impl(dest,
+                 source,
+                 nbytes,
+                 pe,
+                 SCOPE_SUFFIX: core.constexpr,
+                 NBI: core.constexpr = core.constexpr(""),
+                 _semantic=None):
+    return extern_call(
+        "librocshmem_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32):
+            (
+                f"rocshmem_putmem{NBI.value}{SCOPE_SUFFIX.value}_wrapper",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr(""),
+                        core.constexpr(""),
+                        _semantic=_semantic)
+
+
+@core.extern
+def putmem_wave(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr("_wave"),
+                        core.constexpr(""),
+                        _semantic=_semantic)
+
+
+@core.extern
+def putmem_wg(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr("_wg"),
+                        core.constexpr(""),
+                        _semantic=_semantic)
+
+
+@core.extern
+def putmem_nbi(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr(""),
+                        core.constexpr("_nbi"),
+                        _semantic=_semantic)
+
+
+@core.extern
+def putmem_nbi_wave(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr("_wave"),
+                        core.constexpr("_nbi"),
+                        _semantic=_semantic)
+
+
+@core.extern
+def putmem_nbi_wg(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest,
+                        source,
+                        nbytes,
+                        pe,
+                        core.constexpr("_wg"),
+                        core.constexpr("_nbi"),
+                        _semantic=_semantic)
+
+@core.extern
+def _putmem_signal_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, SCOPE_SUFFIX: core.constexpr, NBI: core.constexpr = core.constexpr(""), _semantic=None):
+    tl.static_assert(sig_addr.dtype == tl.pointer_type(tl.int64),
+                     "sig_addr should be a pointer of uint64_t",
+                     _semantic=_semantic)
+    return extern_call(
+        "librocshmem_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(sig_addr, tl.pointer_type(tl.int64), _semantic=_semantic),
+            tl.cast(signal, tl.uint64, _semantic=_semantic),
+            tl.cast(sig_op, tl.int32, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.pointer_type(tl.int64), tl.uint64, tl.int32, tl.int32):
+            (
+                f"rocshmem_putmem_signal{NBI.value}{SCOPE_SUFFIX.value}_wrapper",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+@core.extern
+def putmem_signal(dest,
+                  source,
+                  nbytes,
+                  sig_addr,
+                  signal,
+                  sig_op,
+                  pe,
+                  _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr(""),
+        core.constexpr(""),
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal_wg(dest,
+                  source,
+                  nbytes,
+                  sig_addr,
+                  signal,
+                  sig_op,
+                  pe,
+                  _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr("_wg"),
+        core.constexpr(""),
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal_wave(dest,
+                  source,
+                  nbytes,
+                  sig_addr,
+                  signal,
+                  sig_op,
+                  pe,
+                  _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr("_wave"),
+        core.constexpr(""),
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal_nbi(dest,
+                  source,
+                  nbytes,
+                  sig_addr,
+                  signal,
+                  sig_op,
+                  pe,
+                  _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr(""),
+        core.constexpr("_nbi"),
+        _semantic=_semantic,
+    )
+
+@core.extern
+def putmem_signal_nbi_wg(dest,
+                  source,
+                  nbytes,
+                  sig_addr,
+                  signal,
+                  sig_op,
+                  pe,
+                  _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr("_wg"),
+        core.constexpr("_nbi"),
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal_nbi_wave(dest,
+                  source,
+                  nbytes,
+                  sig_addr,
+                  signal,
+                  sig_op,
+                  pe,
+                  _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr("_wave"),
+        core.constexpr("_nbi"),
+        _semantic=_semantic,
+    )
+
+
+
+
+@core.extern
+def wait_until(sig_addr, cmp_, cmp_val, _semantic=None):
+    tl.static_assert(sig_addr.dtype == pi_u64_t or sig_addr.dtype == pi_i64_t,
+                     "sig_addr should be a pointer of uint64_t/int64_t",
+                     _semantic=_semantic)
+    return extern_call(
+        "librocshmem_device",
+        "",
+        [
+            tl.cast(sig_addr, pi_u64_t, _semantic=_semantic),
+            tl.cast(cmp_, tl.int32, _semantic=_semantic),
+            tl.cast(cmp_val, tl.uint64, _semantic=_semantic),
+        ],  # no cast
+        {
+            (pi_u64_t, tl.int32, tl.uint64): (
+                "rocshmem_wait_until_wrapper",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def _barrier_all_impl(SCOPE_SUFFIX: core.constexpr, _semantic=None):
+    return extern_call(
+        "librocshmem_device",
+        "",
+        [],
+        {
+            ():
+            (f"rocshmem_barrier_all{SCOPE_SUFFIX.value}_wrapper",
+             ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier_all(_semantic=None):
+    return _barrier_all_impl(core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def barrier_all_wave(_semantic=None):
+    return _barrier_all_impl(core.constexpr("_wave"), _semantic=_semantic)
+
+
+@core.extern
+def barrier_all_wg(_semantic=None):
+    return _barrier_all_impl(core.constexpr("_wg"), _semantic=_semantic)
+
+
+@core.extern
+def fence(_semantic=None):
+    return extern_call(
+        "librocshmem_device",
+        "",
+        [],
+        {
+            (): ("rocshmem_fence", ()),
+        },
+        is_pure=False,
         _semantic=_semantic,
     )


### PR DESCRIPTION
This PR extends rocshmem device bitcode support for getmem*/putmem*/signal/barrier device kernel APIs 

