### PR TITLE
[SHMEM] Add an OmniSHMEM Backend for CUDA Platform

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -21,6 +21,8 @@ from pathlib import Path
 import sysconfig
 from string import Template
 
+def check_env_flag(name: str, default: str = "") -> bool:
+    return os.getenv(name, default).upper() in ["ON", "1", "YES", "TRUE", "Y"]
 
 def min_dot_size(target: GPUTarget):
 
@@ -326,6 +328,7 @@ class CUDAOptions:
     extern_libs: dict = None
     nvshmem_device_lib: str = ""
     omnishmem_device_lib: str = ""
+    omnishmem_transfer_device_lib: str = ""
     debug: bool = False
     backend_name: str = 'cuda'
     sanitize_overflow: bool = True
@@ -338,13 +341,15 @@ class CUDAOptions:
             extern_libs['libdevice'] = knobs.nvidia.libdevice_path or str(default_libdir / 'libdevice.10.bc')
         nvshmem_libdir = NVSHMEMHelper.get_nvshmem_lib()
         nvshmem_device_lib = os.getenv("NVSHMEM_LIBDEVICE_PATH", None) or str(nvshmem_libdir / 'libnvshmem_device.bc')
-        nvshmemi_device_lib = os.getenv("NVSHMEMI_LIBDEVICE_PATH", None) or str(nvshmem_libdir / 'libnvshmemi_device.bc')
+        nvshmemi_device_lib = os.getenv("NVSHMEMI_LIBDEVICE_PATH", None) or str(default_libdir / 'libnvshmemi_device.bc')
         omnishmem_device_lib = knobs.nvidia.libdevice_path or str(default_libdir / 'libomnishmem_adaptor_device.bc')
+        omnishmem_transfer_device_lib = os.getenv("OMNISHMEM_LIBDEVICE_PATH", None) or str(default_libdir / 'libomnishmem_transfer_device.bc')
 
         object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
         object.__setattr__(self, 'nvshmem_device_lib', nvshmem_device_lib)
         object.__setattr__(self, 'nvshmemi_device_lib', nvshmemi_device_lib)
         object.__setattr__(self, 'omnishmem_device_lib', omnishmem_device_lib)
+        object.__setattr__(self, 'omnishmem_transfer_device_lib', omnishmem_transfer_device_lib)
         assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
                "num_warps must be a power of 2"
 
@@ -424,7 +429,8 @@ class CUDABackend(BaseBackend):
         from triton.language.extra.cuda import libomnishmem_adaptor_device
         return {"triton.language.extra.libdevice": libdevice,
                 "triton_dist.language.extra.libshmem_device": libnvshmem_device,
-                "triton_dist.language.extra.libomnishmem_device": libomnishmem_adaptor_device}
+                "triton_dist.language.extra.libomnishmem_device": libomnishmem_adaptor_device,
+                }
 
     def load_dialects(self, ctx):
         distributed.ir.load_dialects(ctx)
@@ -600,16 +606,26 @@ class CUDABackend(BaseBackend):
         if options.extern_libs:
             paths = [path for (name, path) in options.extern_libs]
             llvm.link_extern_libs(llvm_mod, paths)
-        if options.nvshmem_device_lib and metadata['use_nvshmem'] and not metadata['use_nvshmem_wrapper']:
+        if options.nvshmem_device_lib: # and metadata['use_nvshmem'] and not metadata['use_nvshmem_wrapper']:
             llvm.link_extern_libs(llvm_mod, [options.nvshmem_device_lib])
-            if os.path.exists(options.nvshmemi_device_lib):
+            print("link nvshmem_device", options.nvshmem_device_lib)
+            # since omnishmem_transfer_device is conflict with nvshmemi_device_lib,
+            # the nvshmemi_device_lib is not linked when the omnishmem enabled.
+            if os.path.exists(options.nvshmemi_device_lib) and not check_env_flag("TRITON_DISTRIBUTED_ENABLE_OMNISHMEM"):
                 # optional: if user don't want to compile the bitcode, just ignore it and can't use nvshmemi functions
                 llvm.link_extern_libs(llvm_mod, [options.nvshmemi_device_lib])
+                print("[INFO] link nvshmemi_device", options.nvshmemi_device_lib)
         
         # Link omnishmem adaptor library if it exists
         if options.omnishmem_device_lib and os.path.exists(options.omnishmem_device_lib):
             llvm.link_extern_libs(llvm_mod, [options.omnishmem_device_lib])
-        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
+            print("[INFO] link omnishmem_device_lib", options.omnishmem_device_lib)
+        # Link omnishmem transfer device library if the omnishmem enabled
+        if os.path.exists(options.omnishmem_transfer_device_lib) and check_env_flag("TRITON_DISTRIBUTED_ENABLE_OMNISHMEM"):
+            llvm.link_extern_libs(llvm_mod, [options.omnishmem_transfer_device_lib])
+            print("[INFO] link omnishmem_transfer_device_lib", options.omnishmem_transfer_device_lib)
+        if not check_env_flag("TRITON_DISTRIBUTED_ENABLE_OMNISHMEM"):
+            llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
 
         # Get some metadata
         # warp-specialization mutates num_warps

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -325,6 +325,7 @@ class CUDAOptions:
     max_num_imprecise_acc_default: bool = None
     extern_libs: dict = None
     nvshmem_device_lib: str = ""
+    omnishmem_device_lib: str = ""
     debug: bool = False
     backend_name: str = 'cuda'
     sanitize_overflow: bool = True
@@ -338,10 +339,12 @@ class CUDAOptions:
         nvshmem_libdir = NVSHMEMHelper.get_nvshmem_lib()
         nvshmem_device_lib = os.getenv("NVSHMEM_LIBDEVICE_PATH", None) or str(nvshmem_libdir / 'libnvshmem_device.bc')
         nvshmemi_device_lib = os.getenv("NVSHMEMI_LIBDEVICE_PATH", None) or str(nvshmem_libdir / 'libnvshmemi_device.bc')
+        omnishmem_device_lib = knobs.nvidia.libdevice_path or str(default_libdir / 'libomnishmem_adaptor_device.bc')
 
         object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
         object.__setattr__(self, 'nvshmem_device_lib', nvshmem_device_lib)
         object.__setattr__(self, 'nvshmemi_device_lib', nvshmemi_device_lib)
+        object.__setattr__(self, 'omnishmem_device_lib', omnishmem_device_lib)
         assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
                "num_warps must be a power of 2"
 
@@ -418,8 +421,10 @@ class CUDABackend(BaseBackend):
     def get_module_map(self) -> Dict[str, ModuleType]:
         from triton.language.extra.cuda import libdevice
         from triton.language.extra.cuda import libnvshmem_device
+        from triton.language.extra.cuda import libomnishmem_adaptor_device
         return {"triton.language.extra.libdevice": libdevice,
-                "triton_dist.language.extra.libshmem_device": libnvshmem_device,}
+                "triton_dist.language.extra.libshmem_device": libnvshmem_device,
+                "triton_dist.language.extra.libomnishmem_device": libomnishmem_adaptor_device}
 
     def load_dialects(self, ctx):
         distributed.ir.load_dialects(ctx)
@@ -600,6 +605,10 @@ class CUDABackend(BaseBackend):
             if os.path.exists(options.nvshmemi_device_lib):
                 # optional: if user don't want to compile the bitcode, just ignore it and can't use nvshmemi functions
                 llvm.link_extern_libs(llvm_mod, [options.nvshmemi_device_lib])
+        
+        # Link omnishmem adaptor library if it exists
+        if options.omnishmem_device_lib and os.path.exists(options.omnishmem_device_lib):
+            llvm.link_extern_libs(llvm_mod, [options.omnishmem_device_lib])
         llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
 
         # Get some metadata

--- a/third_party/nvidia/language/cuda/__init__.py
+++ b/third_party/nvidia/language/cuda/__init__.py
@@ -1,7 +1,7 @@
 ################################################################################
 # Modification Copyright 2025 ByteDance Ltd. and/or its affiliates.
 ################################################################################
-from . import libdevice, libnvshmem_device, language_extra
+from . import libdevice, libnvshmem_device, language_extra, libomnishmem_adaptor_device
 
 from .utils import (globaltimer, num_threads, num_warps, smid, convert_custom_float8_sm70, convert_custom_float8_sm80)
 from .gdc import (gdc_launch_dependents, gdc_wait)

--- a/third_party/nvidia/language/cuda/libomnishmem_adaptor_device.py
+++ b/third_party/nvidia/language/cuda/libomnishmem_adaptor_device.py
@@ -113,7 +113,7 @@ def my_pe(_semantic=None):
 @core.extern
 def device_nvshmem_my_pe(_semantic=None):
     return extern_call(
-        "libomnishmem_adaptor_device",
+        "libnvshmem_device",
         "",
         [],
         {
@@ -470,26 +470,6 @@ def _putmem_impl(dest, source, nbytes, pe, SCOPE_SUFFIX: core.constexpr, NBI: co
             (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32): (
                 f"omnishmem{'x' if SCOPE_SUFFIX.value else ''}_putmem{NBI.value}{SCOPE_SUFFIX.value}",
                 (),
-            ),
-        },
-        is_pure=False,
-        _semantic=_semantic,
-    )
-
-@core.extern
-def nvshmem_putmem_nbi_block(dest, source, nbytes, pe, _semantic=None):
-    return extern_call(
-        "libomnishmem_adaptor_device",
-        "",
-        [
-            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
-            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
-            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
-            tl.cast(pe, tl.int32, _semantic=_semantic),
-        ],
-        {
-            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32): (
-                "nvshmemx_putmem_nbi_block", (),
             ),
         },
         is_pure=False,
@@ -886,12 +866,13 @@ def fcollect_block(team, dest, source, nelems, _semantic=None):
         _semantic=_semantic,
     )
 
+# === support in libomnishmem_transfer_device.bc ===
 
 @core.extern
 def _putmem_rma_impl(dest, source, nbytes, pe, SCOPE_SUFFIX: core.constexpr, NBI: core.constexpr = core.constexpr(""),
                      _semantic=None):
     return extern_call(
-        "libomnishmem_adaptor_device",
+        "libomnishmem_transfer_device",
         "",
         [
             tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
@@ -901,7 +882,7 @@ def _putmem_rma_impl(dest, source, nbytes, pe, SCOPE_SUFFIX: core.constexpr, NBI
         ],
         {
             (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32): (
-                f"omnishmemi_transfer_rma_put{NBI.value}{SCOPE_SUFFIX.value}",
+                f"nvshmemi_transfer_rma_put{NBI.value}{SCOPE_SUFFIX.value}",
                 (),
             ),
         },
@@ -947,7 +928,7 @@ def _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, 
                             NBI: core.constexpr = core.constexpr(""), _semantic=None):
     tl.static_assert(sig_addr.dtype == pi_u64_t, "sig_addr should be a pointer of uint64_t", _semantic=_semantic)
     return extern_call(
-        "libomnishmem_adaptor_device",
+        "libomnishmem_transfer_device",
         "",
         [
             tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
@@ -960,8 +941,7 @@ def _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, 
         ],
         {
             (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, pi_u64_t, tl.uint64, tl.int32, tl.int32): (
-                # omnishmemi_transfer_put_signal_nbi
-                f"omnishmemi_transfer_put_signal{NBI.value}{SCOPE_SUFFIX.value}",
+                f"nvshmemi_transfer_put_signal{NBI.value}{SCOPE_SUFFIX.value}",
                 (),
             ),
         },
@@ -1004,3 +984,16 @@ def putmem_signal_rma_nbi_warp(dest, source, nbytes, sig_addr, signal, sig_op, p
 def putmem_signal_rma_nbi_block(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
     return _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_block"),
                                    core.constexpr("_nbi"), _semantic=_semantic)
+
+@core.extern
+def get_ibgda_init_state(state, pe, _semantic=None):
+    return extern_call(
+        "libomnishmem_transfer_device",
+        "",
+        [state, tl.cast(pe, tl.int32, _semantic=_semantic)],
+        {
+            (tl.pointer_type(tl.uint64), tl.int32): ("omnishmem_check_ibgda_state", ())
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )

--- a/third_party/nvidia/language/cuda/libomnishmem_adaptor_device.py
+++ b/third_party/nvidia/language/cuda/libomnishmem_adaptor_device.py
@@ -1,0 +1,1006 @@
+################################################################################
+#
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+from triton.language import core
+import triton.language as tl
+from triton_dist.language.core import extern_call
+import sys
+
+pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
+
+
+def _pointer_type_hash(self):
+    return hash((self.name, self.element_ty, "tt_ptr"))
+
+
+def patch_hash_method_for_pointer_type():
+    elem_dtype_list = tl.core.dtype.SINT_TYPES + tl.core.dtype.UINT_TYPES + tl.core.dtype.FP_TYPES + tl.core.dtype.OTHER_TYPES
+    for elem_dtype in elem_dtype_list:
+        ptr_ty = type(tl.core.pointer_type(tl.core.dtype(elem_dtype)))
+        ptr_ty.__hash__ = _pointer_type_hash
+
+
+# apply monkey patch in runtime
+patch_hash_method_for_pointer_type()
+
+# class omnishmemi_cmp_type(Enum):
+OMNISHMEM_CMP_EQ = 0
+OMNISHMEM_CMP_NE = 1
+OMNISHMEM_CMP_GT = 2
+OMNISHMEM_CMP_LE = 3
+OMNISHMEM_CMP_LT = 4
+OMNISHMEM_CMP_GE = 5
+OMNISHMEM_CMP_SENTINEL = sys.maxsize
+
+# class omnishmemi_amo_t(Enum):
+OMNISHMEMI_AMO_ACK = 1
+OMNISHMEMI_AMO_INC = 2
+OMNISHMEMI_AMO_SET = 3
+OMNISHMEMI_AMO_ADD = 4
+OMNISHMEMI_AMO_AND = 5
+OMNISHMEMI_AMO_OR = 6
+OMNISHMEMI_AMO_XOR = 7
+OMNISHMEMI_AMO_SIGNAL = 8
+OMNISHMEM_SIGNAL_SET = 9
+OMNISHMEM_SIGNAL_ADD = 10
+OMNISHMEMI_AMO_SIGNAL_SET = OMNISHMEM_SIGNAL_SET  # Note - OMNISHMEM_SIGNAL_SET == 9
+OMNISHMEMI_AMO_SIGNAL_ADD = OMNISHMEM_SIGNAL_ADD  # Note - OMNISHMEM_SIGNAL_ADD == 10
+OMNISHMEMI_AMO_END_OF_NONFETCH = 11  # end of nonfetch atomics
+OMNISHMEMI_AMO_FETCH = 12
+OMNISHMEMI_AMO_FETCH_INC = 13
+OMNISHMEMI_AMO_FETCH_ADD = 14
+OMNISHMEMI_AMO_FETCH_AND = 15
+OMNISHMEMI_AMO_FETCH_OR = 16
+OMNISHMEMI_AMO_FETCH_XOR = 17
+OMNISHMEMI_AMO_SWAP = 18
+OMNISHMEMI_AMO_COMPARE_SWAP = 19
+OMNISHMEMI_AMO_OP_SENTINEL = sys.maxsize
+
+# team node
+OMNISHMEM_TEAM_INVALID = -1
+OMNISHMEM_TEAM_WORLD = 0
+OMNISHMEM_TEAM_WORLD_INDEX = 0
+OMNISHMEM_TEAM_SHARED = 1
+OMNISHMEM_TEAM_SHARED_INDEX = 1
+OMNISHMEMX_TEAM_NODE = 2
+OMNISHMEM_TEAM_NODE_INDEX = 2
+OMNISHMEMX_TEAM_SAME_MYPE_NODE = 3
+OMNISHMEM_TEAM_SAME_MYPE_NODE_INDEX = 3
+OMNISHMEMI_TEAM_SAME_GPU = 4
+OMNISHMEM_TEAM_SAME_GPU_INDEX = 4
+OMNISHMEMI_TEAM_GPU_LEADERS = 5
+OMNISHMEM_TEAM_GPU_LEADERS_INDEX = 5
+OMNISHMEM_TEAMS_MIN = 6
+OMNISHMEM_TEAM_INDEX_MAX = sys.maxsize
+
+void_ptr = core.pointer_type(core.void)
+
+
+@core.extern
+def my_pe(_semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [],
+        {
+            (): ("omnishmem_my_pe", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+@core.extern
+def device_nvshmem_my_pe(_semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [],
+        {
+            (): ("nvshmem_my_pe", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+@core.extern
+def n_pes(_semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [],
+        {
+            (): ("omnishmem_n_pes", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+@core.extern
+def device_nvshmem_n_pes(_semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [],
+        {
+            (): ("nvshmem_n_pes", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+@core.extern
+def team_my_pe(team, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team],
+        {
+            (tl.int32, ): ("omnishmem_team_my_pe", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def team_n_pes(team, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team],
+        {
+            (tl.int32, ): ("omnishmem_team_n_pes", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def int_p(dest, value, pe, _semantic=None):
+    # force have a return value, even not used.
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [dest, value, pe],
+        {(
+            core.pointer_type(core.dtype("int32")),
+            core.dtype("int32"),
+            core.dtype("int32"),
+        ): ("omnishmem_int_p", ()),  # void return type
+         },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def _remote_ptr_wrapper(local_ptr, pe, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [local_ptr, pe],
+        {(core.pointer_type(core.void), core.dtype("int32")): (
+             "omnishmem_ptr", core.pointer_type(core.void),  # of the same dtype
+         )},
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def remote_ptr(local_ptr, pe, _semantic=None):
+    tl.static_assert(
+        local_ptr.dtype.is_ptr(),
+        "remote_ptr(local_ptr, pe) local_ptr should be a pointer",
+        _semantic=_semantic,
+    )
+    tl.static_assert(
+        pe.dtype.is_int(),
+        "remote_ptr(local_ptr, pe) pe should be an integer",
+        _semantic=_semantic,
+    )
+    return tl.cast(
+        _remote_ptr_wrapper(
+            tl.cast(local_ptr, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+            _semantic=_semantic,
+        ),
+        local_ptr.dtype,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def remote_mc_ptr(team, ptr, _semantic=None):
+    tl.static_assert(ptr.type.is_ptr(), "remote_mc_ptr(team, ptr) should be a pointer", _semantic=_semantic)
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [tl.cast(team, tl.int32, _semantic=_semantic),
+         tl.cast(ptr, void_ptr, _semantic=_semantic)],
+        {(tl.int32, void_ptr): (
+             "omnishmemx_mc_ptr", (ptr.type),  # of the same pointer type like ptr
+         )},
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def _barrier_impl(team, SCOPE_SUFFIX: core.constexpr, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team],
+        {
+            (tl.int32, ): (f"omnishmem{'x' if SCOPE_SUFFIX.value else ''}_barrier{SCOPE_SUFFIX.value}", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier(team, _semantic=None):
+    return _barrier_impl(team, core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def barrier_block(team, _semantic=None):
+    return _barrier_impl(team, core.constexpr("_block"), _semantic=_semantic)
+
+
+@core.extern
+def barrier_warp(team, _semantic=None):
+    return _barrier_impl(team, core.constexpr("_warp"), _semantic=_semantic)
+
+
+@core.extern
+def _barrier_all_impl(SCOPE_SUFFIX: core.constexpr, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [],
+        {
+            (): (f"omnishmem{'x' if SCOPE_SUFFIX.value else ''}_barrier_all{SCOPE_SUFFIX.value}", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier_all(_semantic=None):
+    return _barrier_all_impl(core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def barrier_all_block(_semantic=None):
+    return _barrier_all_impl(core.constexpr("_block"), _semantic=_semantic)
+
+
+@core.extern
+def barrier_all_warp(_semantic=None):
+    return _barrier_all_impl(core.constexpr("_warp"), _semantic=_semantic)
+
+
+@core.extern
+def _sync_all_impl(SCOPE_SUFFIX: core.constexpr, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [],
+        {
+            (): (f"omnishmem{'x' if SCOPE_SUFFIX.value else ''}_sync_all{SCOPE_SUFFIX.value}", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def sync_all(_semantic=None):
+    return _sync_all_impl(core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def sync_all_block(_semantic=None):
+    return _sync_all_impl(core.constexpr("_block"), _semantic=_semantic)
+
+
+@core.extern
+def sync_all_warp(_semantic=None):
+    return _sync_all_impl(core.constexpr("_warp"), _semantic=_semantic)
+
+
+@core.extern
+def sync(team, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team],
+        {
+            (tl.int32, ): ("omnishmem_sync", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def _team_sync_impl(team, SCOPE_SUFFIX: core.constexpr, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team],
+        {
+            (tl.int32, ): (f"omnishmemx_team_sync{SCOPE_SUFFIX.value}", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def team_sync_block(team, _semantic=None):
+    return _team_sync_impl(team, core.constexpr("_block"), _semantic=_semantic)
+
+
+@core.extern
+def team_sync_warp(team, _semantic=None):
+    return _team_sync_impl(team, core.constexpr("_warp"), _semantic=_semantic)
+
+
+@core.extern
+def quiet(_semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [],
+        {
+            (): ("omnishmem_quiet", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def fence(_semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [],
+        {
+            (): ("omnishmem_fence", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def _getmem_impl(dest, source, nbytes, pe, SCOPE_SUFFIX: core.constexpr, NBI: core.constexpr = core.constexpr(""),
+                 _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32): (
+                f"omnishmem{'x' if SCOPE_SUFFIX.value else ''}_getmem{NBI.value}{SCOPE_SUFFIX.value}",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def getmem_nbi_block(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest, source, nbytes, pe, core.constexpr("_block"), core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def getmem_block(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest, source, nbytes, pe, core.constexpr("_block"), core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def getmem_nbi_warp(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest, source, nbytes, pe, core.constexpr("_warp"), core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def getmem_warp(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest, source, nbytes, pe, core.constexpr("_warp"), core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def getmem_nbi(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest, source, nbytes, pe, core.constexpr(""), core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def getmem(dest, source, nbytes, pe, _semantic=None):
+    return _getmem_impl(dest, source, nbytes, pe, core.constexpr(""), core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def _putmem_impl(dest, source, nbytes, pe, SCOPE_SUFFIX: core.constexpr, NBI: core.constexpr = core.constexpr(""),
+                 _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32): (
+                f"omnishmem{'x' if SCOPE_SUFFIX.value else ''}_putmem{NBI.value}{SCOPE_SUFFIX.value}",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+@core.extern
+def nvshmem_putmem_nbi_block(dest, source, nbytes, pe, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32): (
+                "nvshmemx_putmem_nbi_block", (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+@core.extern
+def putmem_block(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest, source, nbytes, pe, core.constexpr("_block"), core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def putmem_nbi_block(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest, source, nbytes, pe, core.constexpr("_block"), core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_warp(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest, source, nbytes, pe, core.constexpr("_warp"), core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def putmem_nbi_warp(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest, source, nbytes, pe, core.constexpr("_warp"), core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def putmem(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest, source, nbytes, pe, core.constexpr(""), core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def putmem_nbi(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_impl(dest, source, nbytes, pe, core.constexpr(""), core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def _putmem_signal_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, SCOPE_SUFFIX: core.constexpr,
+                        NBI: core.constexpr = core.constexpr(""), _semantic=None):
+    tl.static_assert(sig_addr.dtype == pi_u64_t, "sig_addr should be a pointer of uint64_t", _semantic=_semantic)
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(sig_addr, pi_u64_t, _semantic=_semantic),  # sig_addr should be a pointer of uint64_t
+            tl.cast(signal, tl.uint64, _semantic=_semantic),
+            tl.cast(sig_op, tl.int32, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, pi_u64_t, tl.uint64, tl.int32, tl.int32): (
+                f"omnishmem{'x' if SCOPE_SUFFIX.value else ''}_putmem_signal{NBI.value}{SCOPE_SUFFIX.value}",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr(""),
+        core.constexpr(""),
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal_nbi(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr(""),
+                               core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_block(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_block"),
+                               core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_nbi_block(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_block"),
+                               core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_warp(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_warp"),
+                               core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_nbi_warp(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_warp"),
+                               core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def signal_op(sig_addr, signal, sig_op, pe, _semantic=None):
+    tl.static_assert(sig_addr.dtype == pi_u64_t, "sig_addr should be a pointer of uint64_t", _semantic=_semantic)
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            tl.cast(sig_addr, pi_u64_t, _semantic=_semantic),  # no cast: pointer type should be aligned
+            tl.cast(signal, tl.uint64, _semantic=_semantic),
+            tl.cast(sig_op, tl.int32, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (pi_u64_t, tl.uint64, tl.int32, tl.int32): (
+                "omnishmemx_signal_op",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def signal_wait_until(sig_addr, cmp_, cmp_val, _semantic=None):
+    tl.static_assert(sig_addr.dtype == pi_u64_t, "sig_addr should be a pointer of uint64_t", _semantic=_semantic)
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            tl.cast(sig_addr, pi_u64_t, _semantic=_semantic),
+            tl.cast(cmp_, tl.int32, _semantic=_semantic),
+            tl.cast(cmp_val, tl.uint64, _semantic=_semantic),
+        ],  # no cast
+        {
+            (pi_u64_t, tl.int32, tl.uint64): (
+                "omnishmem_signal_wait_until",
+                tl.uint64,
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def broadcast(team, dest, source, nelems, pe_root, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team, dest, source, tl.cast(nelems, tl.uint64, _semantic=_semantic), pe_root],  # no cast
+        {
+            (tl.int32, tl.pointer_type(tl.int8), tl.pointer_type(tl.int8), tl.uint64, tl.int32):
+            ("omnishmem_int8_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int16), tl.pointer_type(tl.int16), tl.uint64, tl.int32):
+            ("omnishmem_int16_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int32), tl.pointer_type(tl.int32), tl.uint64, tl.int32):
+            ("omnishmem_int32_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int64), tl.pointer_type(tl.int64), tl.uint64, tl.int32):
+            ("omnishmem_int64_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint8), tl.pointer_type(tl.uint8), tl.uint64, tl.int32):
+            ("omnishmem_uint8_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint16), tl.pointer_type(tl.uint16), tl.uint64, tl.int32):
+            ("omnishmem_uint16_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint32), tl.pointer_type(tl.uint32), tl.uint64, tl.int32):
+            ("omnishmem_uint32_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint64), tl.pointer_type(tl.uint64), tl.uint64, tl.int32):
+            ("omnishmem_uint64_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float16), tl.pointer_type(tl.float16), tl.uint64, tl.int32):
+            ("omnishmem_half_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.bfloat16), tl.pointer_type(tl.bfloat16), tl.uint64, tl.int32):
+            ("omnishmem_bfloat16_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float32), tl.pointer_type(tl.float32), tl.uint64, tl.int32):
+            ("omnishmem_float_broadcast", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float64), tl.pointer_type(tl.float64), tl.uint64, tl.int32):
+            ("omnishmem_double_broadcast", (tl.int32)),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def broadcast_warp(team, dest, source, nelems, pe_root, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team, dest, source, tl.cast(nelems, tl.uint64, _semantic=_semantic), pe_root],  # no cast
+        {
+            (tl.int32, tl.pointer_type(tl.int8), tl.pointer_type(tl.int8), tl.uint64, tl.int32):
+            ("omnishmemx_int8_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int16), tl.pointer_type(tl.int16), tl.uint64, tl.int32):
+            ("omnishmemx_int16_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int32), tl.pointer_type(tl.int32), tl.uint64, tl.int32):
+            ("omnishmemx_int32_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int64), tl.pointer_type(tl.int64), tl.uint64, tl.int32):
+            ("omnishmemx_int64_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint8), tl.pointer_type(tl.uint8), tl.uint64, tl.int32):
+            ("omnishmemx_uint8_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint16), tl.pointer_type(tl.uint16), tl.uint64, tl.int32):
+            ("omnishmemx_uint16_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint32), tl.pointer_type(tl.uint32), tl.uint64, tl.int32):
+            ("omnishmemx_uint32_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint64), tl.pointer_type(tl.uint64), tl.uint64, tl.int32):
+            ("omnishmemx_uint64_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float16), tl.pointer_type(tl.float16), tl.uint64, tl.int32):
+            ("omnishmemx_half_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.bfloat16), tl.pointer_type(tl.bfloat16), tl.uint64, tl.int32):
+            ("omnishmemx_bfloat16_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float32), tl.pointer_type(tl.float32), tl.uint64, tl.int32):
+            ("omnishmemx_float_broadcast_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float64), tl.pointer_type(tl.float64), tl.uint64, tl.int32):
+            ("omnishmemx_double_broadcast_warp", (tl.int32)),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def broadcast_block(team, dest, source, nelems, pe_root, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team, dest, source, tl.cast(nelems, tl.uint64, _semantic=_semantic), pe_root],  # no cast
+        {
+            (tl.int32, tl.pointer_type(tl.int8), tl.pointer_type(tl.int8), tl.uint64, tl.int32):
+            ("omnishmemx_int8_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int16), tl.pointer_type(tl.int16), tl.uint64, tl.int32):
+            ("omnishmemx_int16_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int32), tl.pointer_type(tl.int32), tl.uint64, tl.int32):
+            ("omnishmemx_int32_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int64), tl.pointer_type(tl.int64), tl.uint64, tl.int32):
+            ("omnishmemx_int64_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint8), tl.pointer_type(tl.uint8), tl.uint64, tl.int32):
+            ("omnishmemx_uint8_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint16), tl.pointer_type(tl.uint16), tl.uint64, tl.int32):
+            ("omnishmemx_uint16_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint32), tl.pointer_type(tl.uint32), tl.uint64, tl.int32):
+            ("omnishmemx_uint32_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint64), tl.pointer_type(tl.uint64), tl.uint64, tl.int32):
+            ("omnishmemx_uint64_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float16), tl.pointer_type(tl.float16), tl.uint64, tl.int32):
+            ("omnishmemx_half_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.bfloat16), tl.pointer_type(tl.bfloat16), tl.uint64, tl.int32):
+            ("omnishmemx_bfloat16_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float32), tl.pointer_type(tl.float32), tl.uint64, tl.int32):
+            ("omnishmemx_float_broadcast_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float64), tl.pointer_type(tl.float64), tl.uint64, tl.int32):
+            ("omnishmemx_double_broadcast_block", (tl.int32)),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def broadcastmem_block(team, dest, source, nelems, pe_root, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            team,
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nelems, tl.uint64, _semantic=_semantic),
+            pe_root,
+        ],  # no cast
+        {
+            (tl.int32, tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32):
+            ("omnishmemx_broadcastmem_block", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def fcollect(team, dest, source, nelems, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team, dest, source, tl.cast(nelems, tl.uint64, _semantic=_semantic)],  # no cast
+        {
+            (tl.int32, tl.pointer_type(tl.int8), tl.pointer_type(tl.int8), tl.uint64):
+            ("omnishmem_int8_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int16), tl.pointer_type(tl.int16), tl.uint64):
+            ("omnishmem_int16_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int32), tl.pointer_type(tl.int32), tl.uint64):
+            ("omnishmem_int32_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int64), tl.pointer_type(tl.int64), tl.uint64): 
+            ("omnishmem_int64_fcollect",(tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint8), tl.pointer_type(tl.uint8), tl.uint64): 
+            ("omnishmem_uint8_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint16), tl.pointer_type(tl.uint16), tl.uint64): 
+            ("omnishmem_uint16_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint32), tl.pointer_type(tl.uint32), tl.uint64): 
+            ("omnishmem_uint32_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint64), tl.pointer_type(tl.uint64), tl.uint64): 
+            ("omnishmem_uint64_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float16), tl.pointer_type(tl.float16), tl.uint64): 
+            ("omnishmem_half_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.bfloat16), tl.pointer_type(tl.bfloat16), tl.uint64):
+            ("omnishmem_bfloat16_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float32), tl.pointer_type(tl.float32), tl.uint64): 
+            ("omnishmem_float_fcollect", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float64), tl.pointer_type(tl.float64), tl.uint64): 
+            ("omnishmem_double_fcollect", (tl.int32)),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def fcollect_warp(team, dest, source, nelems, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team, dest, source, tl.cast(nelems, tl.uint64, _semantic=_semantic)],  # no cast
+        {
+            (tl.int32, tl.pointer_type(tl.int8), tl.pointer_type(tl.int8), tl.uint64): 
+            ("omnishmemx_int8_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int16), tl.pointer_type(tl.int16), tl.uint64): 
+            ("omnishmemx_int16_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int32), tl.pointer_type(tl.int32), tl.uint64): 
+            ("omnishmemx_int32_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int64), tl.pointer_type(tl.int64), tl.uint64): 
+            ("omnishmemx_int64_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint8), tl.pointer_type(tl.uint8), tl.uint64): 
+            ("omnishmemx_uint8_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint16), tl.pointer_type(tl.uint16), tl.uint64): 
+            ("omnishmemx_uint16_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint32), tl.pointer_type(tl.uint32), tl.uint64):
+            ("omnishmemx_uint32_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint64), tl.pointer_type(tl.uint64), tl.uint64):
+            ("omnishmemx_uint64_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float16), tl.pointer_type(tl.float16), tl.uint64):
+            ("omnishmemx_half_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.bfloat16), tl.pointer_type(tl.bfloat16), tl.uint64):
+            ("omnishmemx_bfloat16_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float32), tl.pointer_type(tl.float32), tl.uint64):
+            ("omnishmemx_float_fcollect_warp", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float64), tl.pointer_type(tl.float64), tl.uint64):
+            ("omnishmemx_double_fcollect_warp", (tl.int32)),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def fcollect_block(team, dest, source, nelems, _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [team, dest, source, tl.cast(nelems, tl.uint64, _semantic=_semantic)],  # no cast
+        {
+            (tl.int32, tl.pointer_type(tl.int8), tl.pointer_type(tl.int8), tl.uint64): 
+            ("omnishmemx_int8_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int16), tl.pointer_type(tl.int16), tl.uint64):
+            ("omnishmemx_int16_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int32), tl.pointer_type(tl.int32), tl.uint64):
+            ("omnishmemx_int32_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.int64), tl.pointer_type(tl.int64), tl.uint64):
+            ("omnishmemx_int64_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint8), tl.pointer_type(tl.uint8), tl.uint64):
+            ("omnishmemx_uint8_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint16), tl.pointer_type(tl.uint16), tl.uint64):
+            ("omnishmemx_uint16_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint32), tl.pointer_type(tl.uint32), tl.uint64):
+            ("omnishmemx_uint32_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.uint64), tl.pointer_type(tl.uint64), tl.uint64):
+            ("omnishmemx_uint64_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float16), tl.pointer_type(tl.float16), tl.uint64):
+            ("omnishmemx_half_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.bfloat16), tl.pointer_type(tl.bfloat16), tl.uint64):
+            ("omnishmemx_bfloat16_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float32), tl.pointer_type(tl.float32), tl.uint64):
+            ("omnishmemx_float_fcollect_block", (tl.int32)),
+            (tl.int32, tl.pointer_type(tl.float64), tl.pointer_type(tl.float64), tl.uint64):
+            ("omnishmemx_double_fcollect_block", (tl.int32)),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def _putmem_rma_impl(dest, source, nbytes, pe, SCOPE_SUFFIX: core.constexpr, NBI: core.constexpr = core.constexpr(""),
+                     _semantic=None):
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, tl.int32): (
+                f"omnishmemi_transfer_rma_put{NBI.value}{SCOPE_SUFFIX.value}",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_rma(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_rma_impl(dest, source, nbytes, pe, core.constexpr(""), _semantic=_semantic)
+
+
+@core.extern
+def putmem_rma_warp(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_rma_impl(dest, source, nbytes, pe, core.constexpr("_warp"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_rma_block(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_rma_impl(dest, source, nbytes, pe, core.constexpr("_block"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_rma_nbi(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_rma_impl(dest, source, nbytes, pe, core.constexpr(""), core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_rma_nbi_warp(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_rma_impl(dest, source, nbytes, pe, core.constexpr("_warp"), core.constexpr("_nbi"),
+                            _semantic=_semantic)
+
+
+@core.extern
+def putmem_rma_nbi_block(dest, source, nbytes, pe, _semantic=None):
+    return _putmem_rma_impl(dest, source, nbytes, pe, core.constexpr("_block"), core.constexpr("_nbi"),
+                            _semantic=_semantic)
+
+
+@core.extern
+def _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, SCOPE_SUFFIX: core.constexpr,
+                            NBI: core.constexpr = core.constexpr(""), _semantic=None):
+    tl.static_assert(sig_addr.dtype == pi_u64_t, "sig_addr should be a pointer of uint64_t", _semantic=_semantic)
+    return extern_call(
+        "libomnishmem_adaptor_device",
+        "",
+        [
+            tl.cast(dest, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(source, tl.pointer_type(tl.void), _semantic=_semantic),
+            tl.cast(nbytes, tl.uint64, _semantic=_semantic),
+            tl.cast(sig_addr, pi_u64_t, _semantic=_semantic),  # no cast: pointer type should be aligned
+            tl.cast(signal, tl.uint64, _semantic=_semantic),
+            tl.cast(sig_op, tl.int32, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.pointer_type(tl.void), tl.pointer_type(tl.void), tl.uint64, pi_u64_t, tl.uint64, tl.int32, tl.int32): (
+                # omnishmemi_transfer_put_signal_nbi
+                f"omnishmemi_transfer_put_signal{NBI.value}{SCOPE_SUFFIX.value}",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal_rma(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr(""),
+                                   _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_rma_warp(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_warp"),
+                                   _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_rma_block(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_block"),
+                                   _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_rma_nbi(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr(""),
+                                   core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_rma_nbi_warp(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_warp"),
+                                   core.constexpr("_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_signal_rma_nbi_block(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_rma_impl(dest, source, nbytes, sig_addr, signal, sig_op, pe, core.constexpr("_block"),
+                                   core.constexpr("_nbi"), _semantic=_semantic)


### PR DESCRIPTION
This PR adds a new OmniSHMEM library backend under the CUDA platform. It enables Triton to link against the OmniSHMEM bitcode library during the compilation phase and invoke functions from the library via external calls.