### PR TITLE
feat: add support for AMD more intrinsics

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -85,10 +85,13 @@ class HIPOptions:
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
         for lib in ["ocml", "ockl"]:
             extern_libs[lib] = str(default_libdir / f'{lib}.bc')
+
+        libdevice_extra = str(default_libdir / f"libdevice_extra.ll")
         rocshmem_device_lib = str(default_libdir / 'librocshmem_device.bc')
 
         object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
         object.__setattr__(self, 'rocshmem_device_lib', rocshmem_device_lib)
+        object.__setattr__(self, 'libdevice_extra', libdevice_extra)
 
     def hash(self):
         key = '_'.join([f'{name}-{val}' for name, val in self.__dict__.items()])
@@ -406,6 +409,9 @@ class HIPBackend(BaseBackend):
         elif options.extern_libs:
             paths = [path for (name, path) in options.extern_libs if amd.need_extern_lib(llvm_mod, name)]
             llvm.link_extern_libs(llvm_mod, paths)
+
+        if options.libdevice_extra:
+            llvm.link_extern_libs(llvm_mod, [options.libdevice_extra])
 
         if options.rocshmem_device_lib and metadata['use_rocshmem']:
             llvm.link_extern_libs(llvm_mod, [options.rocshmem_device_lib])

--- a/third_party/amd/backend/lib/libdevice_extra.ll
+++ b/third_party/amd/backend/lib/libdevice_extra.ll
@@ -1,0 +1,509 @@
+; ModuleID = './3rdparty/triton/third_party/amd/backend/lib/libdevice_extra.ll'
+source_filename = "llvm-link"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"
+target triple = "amdgcn-amd-amdhsa"
+
+
+
+define linkonce hidden i32 @__load_acquire_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i32, ptr addrspace(1) %0 syncscope("workgroup-one-as") acquire, align 4
+  ret i32 %2
+}
+
+
+define linkonce hidden i32 @__load_acquire_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i32, ptr addrspace(1) %0 syncscope("agent-one-as") acquire, align 4
+  ret i32 %2
+}
+
+
+define linkonce hidden i32 @__load_acquire_system_i32(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i32, ptr addrspace(1) %0  acquire, align 4
+  ret i32 %2
+}
+
+
+define linkonce hidden i32 @__load_monotonic_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i32, ptr addrspace(1) %0 syncscope("workgroup-one-as") monotonic, align 4
+  ret i32 %2
+}
+
+
+define linkonce hidden i32 @__load_monotonic_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i32, ptr addrspace(1) %0 syncscope("agent-one-as") monotonic, align 4
+  ret i32 %2
+}
+
+
+define linkonce hidden i32 @__load_monotonic_system_i32(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i32, ptr addrspace(1) %0  monotonic, align 4
+  ret i32 %2
+}
+
+
+define linkonce hidden i64 @__load_acquire_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i64, ptr addrspace(1) %0 syncscope("workgroup-one-as") acquire, align 8
+  ret i64 %2
+}
+
+
+define linkonce hidden i64 @__load_acquire_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i64, ptr addrspace(1) %0 syncscope("agent-one-as") acquire, align 8
+  ret i64 %2
+}
+
+
+define linkonce hidden i64 @__load_acquire_system_i64(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i64, ptr addrspace(1) %0  acquire, align 8
+  ret i64 %2
+}
+
+
+define linkonce hidden i64 @__load_monotonic_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i64, ptr addrspace(1) %0 syncscope("workgroup-one-as") monotonic, align 8
+  ret i64 %2
+}
+
+
+define linkonce hidden i64 @__load_monotonic_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i64, ptr addrspace(1) %0 syncscope("agent-one-as") monotonic, align 8
+  ret i64 %2
+}
+
+
+define linkonce hidden i64 @__load_monotonic_system_i64(ptr addrspace(1) inreg readonly captures(none) %0) local_unnamed_addr {
+  %2 = load atomic i64, ptr addrspace(1) %0  monotonic, align 8
+  ret i64 %2
+}
+
+
+define linkonce hidden i32 @__store_monotonic_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  store atomic i32 %1, ptr addrspace(1) %0 syncscope("workgroup-one-as") monotonic, align 4
+  ret i32 %1
+}
+
+
+define linkonce hidden i32 @__store_monotonic_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  store atomic i32 %1, ptr addrspace(1) %0 syncscope("agent-one-as") monotonic, align 4
+  ret i32 %1
+}
+
+
+define linkonce hidden i32 @__store_monotonic_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  store atomic i32 %1, ptr addrspace(1) %0  monotonic, align 4
+  ret i32 %1
+}
+
+
+define linkonce hidden i32 @__store_release_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  store atomic i32 %1, ptr addrspace(1) %0 syncscope("workgroup-one-as") release, align 4
+  ret i32 %1
+}
+
+
+define linkonce hidden i32 @__store_release_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  store atomic i32 %1, ptr addrspace(1) %0 syncscope("agent-one-as") release, align 4
+  ret i32 %1
+}
+
+
+define linkonce hidden i32 @__store_release_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  store atomic i32 %1, ptr addrspace(1) %0  release, align 4
+  ret i32 %1
+}
+
+
+define linkonce hidden i64 @__store_monotonic_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  store atomic i64 %1, ptr addrspace(1) %0 syncscope("workgroup-one-as") monotonic, align 8
+  ret i64 %1
+}
+
+
+define linkonce hidden i64 @__store_monotonic_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  store atomic i64 %1, ptr addrspace(1) %0 syncscope("agent-one-as") monotonic, align 8
+  ret i64 %1
+}
+
+
+define linkonce hidden i64 @__store_monotonic_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  store atomic i64 %1, ptr addrspace(1) %0  monotonic, align 8
+  ret i64 %1
+}
+
+
+define linkonce hidden i64 @__store_release_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  store atomic i64 %1, ptr addrspace(1) %0 syncscope("workgroup-one-as") release, align 8
+  ret i64 %1
+}
+
+
+define linkonce hidden i64 @__store_release_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  store atomic i64 %1, ptr addrspace(1) %0 syncscope("agent-one-as") release, align 8
+  ret i64 %1
+}
+
+
+define linkonce hidden i64 @__store_release_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  store atomic i64 %1, ptr addrspace(1) %0  release, align 8
+  ret i64 %1
+}
+
+
+define linkonce hidden i32 @__atomic_add_acquire_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1 syncscope("workgroup-one-as") acquire, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_acquire_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1 syncscope("agent-one-as") acquire, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_acquire_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1  acquire, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_monotonic_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1 syncscope("workgroup-one-as") monotonic, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_monotonic_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1 syncscope("agent-one-as") monotonic, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_monotonic_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1  monotonic, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_release_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1 syncscope("workgroup-one-as") release, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_release_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1 syncscope("agent-one-as") release, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_release_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1  release, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_acq_rel_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1 syncscope("workgroup-one-as") acq_rel, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_acq_rel_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1 syncscope("agent-one-as") acq_rel, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i32 @__atomic_add_acq_rel_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i32 %1  acq_rel, align 4
+  ret i32 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_acquire_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1 syncscope("workgroup-one-as") acquire, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_acquire_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1 syncscope("agent-one-as") acquire, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_acquire_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1  acquire, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_monotonic_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1 syncscope("workgroup-one-as") monotonic, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_monotonic_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1 syncscope("agent-one-as") monotonic, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_monotonic_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1  monotonic, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_release_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1 syncscope("workgroup-one-as") release, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_release_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1 syncscope("agent-one-as") release, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_release_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1  release, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_acq_rel_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1 syncscope("workgroup-one-as") acq_rel, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_acq_rel_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1 syncscope("agent-one-as") acq_rel, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i64 @__atomic_add_acq_rel_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1) local_unnamed_addr {
+  %3 = atomicrmw add ptr addrspace(1) %0, i64 %1  acq_rel, align 8
+  ret i64 %3
+}
+
+
+define linkonce hidden i32 @__atom_cas_acquire_monotonic_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2 syncscope("workgroup-one-as") acquire monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_acquire_monotonic_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2 syncscope("agent-one-as") acquire monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_acquire_monotonic_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2  acquire monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_monotonic_monotonic_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2 syncscope("workgroup-one-as") monotonic monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_monotonic_monotonic_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2 syncscope("agent-one-as") monotonic monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_monotonic_monotonic_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2  monotonic monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_release_monotonic_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2 syncscope("workgroup-one-as") release monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_release_monotonic_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2 syncscope("agent-one-as") release monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_release_monotonic_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2  release monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_acq_rel_monotonic_workgroup_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2 syncscope("workgroup-one-as") acq_rel monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_acq_rel_monotonic_agent_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2 syncscope("agent-one-as") acq_rel monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i32 @__atom_cas_acq_rel_monotonic_system_i32(ptr addrspace(1) inreg readonly captures(none) %0, i32 %1, i32 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i32 %1, i32 %2  acq_rel monotonic, align 4
+  %11 = extractvalue { i32, i1 } %10, 0
+  ret i32 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_acquire_monotonic_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2 syncscope("workgroup-one-as") acquire monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_acquire_monotonic_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2 syncscope("agent-one-as") acquire monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_acquire_monotonic_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2  acquire monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_monotonic_monotonic_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2 syncscope("workgroup-one-as") monotonic monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_monotonic_monotonic_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2 syncscope("agent-one-as") monotonic monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_monotonic_monotonic_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2  monotonic monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_release_monotonic_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2 syncscope("workgroup-one-as") release monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_release_monotonic_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2 syncscope("agent-one-as") release monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_release_monotonic_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2  release monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_acq_rel_monotonic_workgroup_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2 syncscope("workgroup-one-as") acq_rel monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_acq_rel_monotonic_agent_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2 syncscope("agent-one-as") acq_rel monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}
+
+
+define linkonce hidden i64 @__atom_cas_acq_rel_monotonic_system_i64(ptr addrspace(1) inreg readonly captures(none) %0, i64 %1, i64 %2) local_unnamed_addr {
+  ; %1 => value
+  ; %2 => target value
+  %10 = cmpxchg ptr addrspace(1) %0, i64 %1, i64 %2  acq_rel monotonic, align 8
+  %11 = extractvalue { i64, i1 } %10, 0
+  ret i64 %11
+}

--- a/third_party/amd/language/hip/libdevice_extra.py
+++ b/third_party/amd/language/hip/libdevice_extra.py
@@ -1,0 +1,93 @@
+from triton.language import core
+from triton_dist.language import core as dist_core
+
+@core.extern
+def load(ptr, semantic="monotonic", scope="agent", _semantic=None):
+    """
+    semantic should be one of ["monotonic", "acquire"]
+    scope should be one of ["workgroup", "agent", "system]
+    """
+    return dist_core.extern_elementwise(
+        "", "", [ptr], {
+            (core.pointer_type(core.dtype("int32")), ): (f"__load_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("int32")),
+            (core.pointer_type(core.dtype("int64")), ): (f"__load_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i64", core.dtype("int64")),
+            (core.pointer_type(core.dtype("uint32")), ): (f"__load_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("uint32")),
+            (core.pointer_type(core.dtype("uint64")), ): (f"__load_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("uint64")),
+        }, is_pure=False, _semantic=_semantic)
+
+@core.extern
+def store(ptr, val, semantic="monotonic", scope="agent", _semantic=None):
+    """
+    semantic should be one of ["monotonic", "release"]
+    scope should be one of ["workgroup", "agent", "system]
+    """
+    if isinstance(val, core.constexpr):
+        core.static_assert(val.value == int, _semantic=_semantic)
+    else:
+        core.static_assert(val.dtype == core.dtype("int32") or val.dtype == core.dtype("int64") or val.dtype == core.dtype("uint32"), _semantic=_semantic)
+    return dist_core.extern_elementwise(
+        "", "", [ptr, core.cast(val, dtype=ptr.dtype.element_ty, _semantic=_semantic)], {
+            (core.pointer_type(core.dtype("int32")), core.dtype("int32")): (f"__store_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("int32")),
+            (core.pointer_type(core.dtype("uint32")), core.dtype("uint32")): (f"__store_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("uint32")),
+            (core.pointer_type(core.dtype("int64")), core.dtype("int64")): (f"__store_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i64", core.dtype("int64")),
+            (core.pointer_type(core.dtype("uint64")), core.dtype("uint64")): (f"__store_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i64", core.dtype("uint64")),
+        }, is_pure=False, _semantic=_semantic)
+
+@core.extern
+def atomic_add(ptr, val, semantic="monotonic", scope="agent", _semantic=None):
+    """
+    semantic should be one of ["monotonic", "release", "acquire", "acq_rel]
+    scope should be one of ["workgroup", "agent", "system]
+    """
+    if isinstance(val, core.constexpr):
+        core.static_assert(val.value == int, _semantic=_semantic)
+    else:
+        core.static_assert(val.dtype == core.dtype("int32") or val.dtype == core.dtype("int64"), _semantic=_semantic)
+    return dist_core.extern_elementwise(
+        "", "", [ptr, core.cast(val, dtype=ptr.dtype.element_ty, _semantic=_semantic)], {
+            (core.pointer_type(core.dtype("int32")), core.dtype("int32")): (f"__atomic_add_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("int32")),
+            (core.pointer_type(core.dtype("uint32")), core.dtype("uint32")): (f"__atomic_add_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("uint32")),
+            (core.pointer_type(core.dtype("int64")), core.dtype("int64")): (f"__atomic_add_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i64", core.dtype("int64")),
+            (core.pointer_type(core.dtype("uint64")), core.dtype("uint64")): (f"__atomic_add_{core._unwrap_if_constexpr(semantic)}_{core._unwrap_if_constexpr(scope)}_i64", core.dtype("uint64")),
+        }, is_pure=False, _semantic=_semantic)
+
+@core.extern
+def atomic_cas(ptr, val, target_val, semantic="monotonic", scope="agent", _semantic=None):
+    """
+    run this atomic:
+    {
+        old = *ptr;
+        if (old == val) *ptr = target_value;
+        return old;
+    }
+
+    semantic should be one of ["monotonic", "release", "acquire", "acq_rel]
+    scope should be one of ["workgroup", "agent", "system]
+    semantic only works when compare `old == val` success
+    """
+    if isinstance(val, core.constexpr):
+        core.static_assert(val.value == int, _semantic=_semantic)
+    else:
+        core.static_assert(val.dtype == core.dtype("int32") or val.dtype == core.dtype("int64"), _semantic=_semantic)
+
+    if isinstance(target_val, core.constexpr):
+        core.static_assert(target_val.value == int, _semantic=_semantic)
+    else:
+        core.static_assert(target_val.dtype == core.dtype("int32") or target_val.dtype == core.dtype("int64"), _semantic=_semantic)
+
+    return dist_core.extern_elementwise(
+        "", "", [ptr, core.cast(val, dtype=ptr.dtype.element_ty, _semantic=_semantic), core.cast(target_val, dtype=ptr.dtype.element_ty, _semantic=_semantic)], {
+            (core.pointer_type(core.dtype("int32")), core.dtype("int32"), core.dtype("int32")): (f"__atom_cas_{core._unwrap_if_constexpr(semantic)}_monotonic_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("int32")),
+            (core.pointer_type(core.dtype("uint32")), core.dtype("uint32"), core.dtype("uint32")): (f"__atom_cas_{core._unwrap_if_constexpr(semantic)}_monotonic_{core._unwrap_if_constexpr(scope)}_i32", core.dtype("uint32")),
+            (core.pointer_type(core.dtype("int64")), core.dtype("int64"), core.dtype("int64")): (f"__atom_cas_{core._unwrap_if_constexpr(semantic)}_monotonic_{core._unwrap_if_constexpr(scope)}_i64", core.dtype("int64")),
+            (core.pointer_type(core.dtype("uint64")), core.dtype("uint64"), core.dtype("uint64")): (f"__atom_cas_{core._unwrap_if_constexpr(semantic)}_monotonic_{core._unwrap_if_constexpr(scope)}_i64", core.dtype("uint64")),
+        }, is_pure=False, _semantic=_semantic)
+
+
+@core.extern
+def sync_grid(_semantic=None):
+    return dist_core.extern_elementwise(
+        "", "", [], {
+            tuple(): (f"__ockl_grid_sync", core.dtype("int32")), # does not return
+        }, is_pure=False, _semantic=_semantic
+    )


### PR DESCRIPTION

# ChangeLog

* add some intrisic for AMD, including sync_grid, also some already existings load/store/atomic_add/atomic_cas.

some NOTE: 
* don't need to modify C++ files to add load/store/atomic_add/atomic_cas
* keep the libdevice_extra.py as llvm ir (.ll) instead of bitcode (.bc) for future change.
* always link the libdevice_extra.ll make the link slow very little bit, and add a little more symbols, but not so many.
