### PR TITLE
keep divisiblity for dl.symm_at

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1053,6 +1053,7 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver,
   // Distributed ops
   visitors
       .append<BarrierOpAxisInfoVisitor<triton::distributed::ConsumeTokenOp>>();
+  visitors.append<CastOpAxisInfoVisitor<triton::distributed::SymmAtOp>>();
 
   if (callback)
     callback(visitors);


### PR DESCRIPTION

## the background

for dl.symm_at in triton.jit

```python
   peer_ptr = dl.symm_at(ptr, rank)
   peer_ptr = tl.multiple_of(ptr, 16)  # hint the compiler to vectorize the read/write operation on ptr. which may not be true if ptr is not 16-aligned
```

peer_ptr loss the divisibility=16, which makes it impossible for memory coalease read/write.

* nvshmem/rocshmem the heap base is all 16-byte aligned, which means ptr and peer_ptr shares the same divisiblity. 
* dl.symm_at works as some kind-of cast ptr, and so use CastOpAxisInfoVisitor<triton::distributed::SymmAtOp>

## The affect

no need to write `tl.multiple_of` any more

```python
   peer_ptr = dl.symm_at(ptr, rank) # this is enough for the triton compiler to do the vectorization
```