### PR TITLE
[AMD] Remove code object version specification

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -352,7 +352,6 @@ class HIPBackend(BaseBackend):
         # Set various control constants on the LLVM module so that device
         # libraries can resolve references to them.
         amd.set_isa_version(llvm_mod, options.arch)
-        amd.set_abi_version(llvm_mod, 500)
         amd.set_bool_control_constant(llvm_mod, "__oclc_finite_only_opt", False)
         amd.set_bool_control_constant(llvm_mod, "__oclc_correctly_rounded_sqrt32", True)
         amd.set_bool_control_constant(llvm_mod, "__oclc_unsafe_math_opt", False)


### PR DESCRIPTION
Rocm7.1+ uses code object v6, so explicitly setting v5 (500) would break llvm module compilation
Tested with local rocm7.1 installation.